### PR TITLE
Edit producer_plugin.cpp to show clear description of how to use sign…

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -427,7 +427,7 @@ void producer_plugin::set_program_options(
           "   <provider-spec> \tis a string in the form <provider-type>:<data>\n\n"
           "   <provider-type> \tis KEY, or KEOSD\n\n"
           "   KEY:<data>      \tis a string form of a valid EOSIO private key which maps to the provided public key\n\n"
-          "   KEOSD:<data>    \tis the URL where keosd is available and the approptiate wallet(s) are unlocked")
+          "   KEOSD:<data>    \tis the URL where keosd is available and the approptiate wallet(s) are unlocked. Example <data>: http://{ServerIP}:{ServerPort}/v1/wallet/sign_digest")
          ("keosd-provider-timeout", boost::program_options::value<int32_t>()->default_value(5),
           "Limits the maximum time (in milliseconds) that is allowd for sending blocks to a keosd provider for signing")
          ;


### PR DESCRIPTION
…ature-provider + KEOSD

It's currently not clear that the user needs to add the "/v1/wallet/sign_digest" uri to the address of the keosd server.